### PR TITLE
nest es5 as a dep of jsx and es2015

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ node_js:
   - "0.12"
   - "0.10"
 after_success: npm run coveralls
+cache:
+  directories:
+    - node_modules

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ npm install --save-dev eslint
 
 Now that you have eslint installed, you can extend one or multiple of the eslint configs contained.
 
-There are three configs:
+There are three configs contained in this repo:
+
 * [eslint-config-uber-es5](packages/eslint-config-uber-es5)
 * [eslint-config-uber-es2015](packages/eslint-config-uber-es2015)
 * [eslint-config-uber-jsx](packages/eslint-config-uber-jsx)
@@ -30,7 +31,7 @@ npm install --save-dev eslint-config-uber-es5
 
 Initialize a `.eslintrc` file or append to an existing one.
 
-*You could also use a `.eslintrc.json` file instead*
+*Note: you can also configure eslint with [other types of config files](http://eslint.org/docs/user-guide/configuring#configuration-file-formats)*
 
 #### Before
 
@@ -43,19 +44,21 @@ Initialize a `.eslintrc` file or append to an existing one.
 
 #### After
 
-(Assuming you are writing es2015 (es6) JavaScript, you'd enable these two configs)
+Assuming you are writing es2015 jsx, you'd enable it like so:
 
 ```js
 {
   "rules": {},
   "extends": [
-    "eslint-config-uber-es5",
-    "eslint-config-uber-es2015"
+    "eslint-config-uber-es2015",
+    "eslint-config-uber-jsx"
   ]
 }
 ```
 
-You can also mix these configs together with external eslint configs.
+You can also mix these with external eslint configs.
+
+===
 
 See [eslint docs](http://eslint.org/) for more information.
 

--- a/packages/eslint-config-uber-es2015/.eslintrc.json
+++ b/packages/eslint-config-uber-es2015/.eslintrc.json
@@ -1,4 +1,7 @@
 {
+  "extends": [
+    "eslint-config-uber-es5"
+  ],
   "env": {
     "es6": true
   },

--- a/packages/eslint-config-uber-es2015/.eslintrc.jsx.json
+++ b/packages/eslint-config-uber-es2015/.eslintrc.jsx.json
@@ -1,0 +1,6 @@
+{
+  "extends": [
+    ".eslintrc.json",
+    "eslint-config-uber-jsx"
+  ]
+}

--- a/packages/eslint-config-uber-es2015/README.md
+++ b/packages/eslint-config-uber-es2015/README.md
@@ -20,18 +20,14 @@ npm install --save-dev eslint-config-uber-es2015
 
 Initialize a `.eslintrc` file or append to an existing one.
 
-*Note: you can also use a `.eslintrc.json` file instead*
+*Note: you can also configure eslint with [other types of config files](http://eslint.org/docs/user-guide/configuring#configuration-file-formats)*
 
 #### Before
-
-*You'll want to extend from `eslint-config-uber-base` first since some es2015 rules depend on the base rules.*
 
 ```js
 {
   "rules": {},
-  "extends": [
-    "eslint-config-uber-base"
-  ]
+  "extends": []
 }
 ```
 
@@ -41,13 +37,17 @@ Initialize a `.eslintrc` file or append to an existing one.
 {
   "rules": {},
   "extends": [
-    "eslint-config-uber-base",
     "eslint-config-uber-es2015"
   ]
 }
 ```
 
-See [eslint docs](http://eslint.org/) for more information.
+*`eslint-config-uber-es5` is already included, so there's no need to extend it.*
+
+===
+
+[:back: to uber-eslint home](../../README.md)
+
 
 [npm-image]: https://badge.fury.io/js/eslint-config--uber-es2015.svg
 [npm-url]: https://npmjs.org/package/eslint-config-uber-es2015

--- a/packages/eslint-config-uber-es2015/package.json
+++ b/packages/eslint-config-uber-es2015/package.json
@@ -29,11 +29,15 @@
   },
   "devDependencies": {
     "eslint": "^2.0.0",
+    "eslint-config-uber-jsx": "^1.0.0",
     "tape": "^4.0.0"
   },
   "engines": {
     "node": ">=0.10.0",
     "npm": ">=2.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "eslint-config-uber-es5": "^1.0.0"
+  }
 }

--- a/packages/eslint-config-uber-es2015/test/fixtures/fail.js
+++ b/packages/eslint-config-uber-es2015/test/fixtures/fail.js
@@ -18,5 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-var something = "test";
+var b, a;
 let sq = p1=> p1*p1;
+var camel_case = "test";

--- a/packages/eslint-config-uber-es2015/test/index.js
+++ b/packages/eslint-config-uber-es2015/test/index.js
@@ -3,6 +3,7 @@
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
+
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
@@ -46,15 +47,37 @@ test('a passing lint', function t(assert) {
 
 test('a failing lint', function t(assert) {
   var lintFile = path.join(__dirname, 'fixtures/fail.js');
-  exec('eslint -c .eslintrc.json ' + lintFile, function onLint(err, stderr, stdout) {
+  exec('eslint ' + lintFile, function onLint(err, stderr, stdout) {
     assert.ok(err, 'exits with non-zero exit code');
     stderr = stderr.toString();
+    // es2015 rules
     assert.ok(stderr.indexOf('prefer-const') >= 0,
-      'fails use strict rule');
+      'fails use prefer-const rule');
     assert.ok(stderr.indexOf('arrow-spacing') >= 0,
       'fails arrow-spacing rule');
     assert.ok(stderr.indexOf('no-var') >= 0,
       'fails the no-var rule');
+    // es5 rules
+    assert.ok(stderr.indexOf('quotes') >= 0,
+      'fails the quotes rule');
+    assert.ok(stderr.indexOf('camel_case') >= 0,
+      'fails the camel_case rule');
+    assert.ok(stderr.indexOf('sort-vars') >= 0,
+      'fails use sort-vars');
+    assert.end();
+  });
+});
+
+test('jsx integration - a failing lint', function t(assert) {
+  var lintFile = path.join(__dirname, 'fixtures/fail.js');
+  exec('eslint -c .eslintrc.jsx.json ' + lintFile, function onLint(err, stderr, stdout) {
+    assert.ok(err, 'exits with non-zero exit code');
+    stderr = stderr.toString();
+    // ensures that extending uber-jsx does not mangle uber-es2015 override
+    assert.ok(stderr.indexOf('camelcase') === -1,
+      'passes the camelcase rule');
+    assert.ok(stderr.indexOf('sort-vars') === -1,
+      'fails use sort-vars');
     assert.end();
   });
 });

--- a/packages/eslint-config-uber-es5/README.md
+++ b/packages/eslint-config-uber-es5/README.md
@@ -20,7 +20,7 @@ npm install --save-dev eslint-config-uber-es5
 
 Initialize a `.eslintrc` file or append to an existing one.
 
-*Note: you can also use a `.eslintrc.json` file instead*
+*Note: you can also configure eslint with [other types of config files](http://eslint.org/docs/user-guide/configuring#configuration-file-formats)*
 
 #### Before
 
@@ -42,7 +42,9 @@ Initialize a `.eslintrc` file or append to an existing one.
 }
 ```
 
-See [eslint docs](http://eslint.org/) for more information.
+===
+
+[:back: to uber-eslint home](../../README.md)
 
 [npm-image]: https://badge.fury.io/js/eslint-config-uber-es5.svg
 [npm-url]: https://npmjs.org/package/eslint-config-uber-es5

--- a/packages/eslint-config-uber-jsx/.eslintrc.es2015.json
+++ b/packages/eslint-config-uber-jsx/.eslintrc.es2015.json
@@ -1,6 +1,5 @@
 {
   "extends": [
-    "eslint-config-uber-es5",
     "eslint-config-uber-es2015",
     ".eslintrc.json"
   ]

--- a/packages/eslint-config-uber-jsx/.eslintrc.json
+++ b/packages/eslint-config-uber-jsx/.eslintrc.json
@@ -1,4 +1,7 @@
 {
+  "extends": [
+    "eslint-config-uber-es5"
+  ],
   "parserOptions": {
     "ecmaFeatures": {
       "jsx": true

--- a/packages/eslint-config-uber-jsx/README.md
+++ b/packages/eslint-config-uber-jsx/README.md
@@ -20,18 +20,14 @@ npm install --save-dev eslint-config-uber-jsx
 
 Initialize a `.eslintrc` file or append to an existing one.
 
-*Note: you can also use a `.eslintrc.json` file instead*
+*Note: you can also configure eslint with [other types of config files](http://eslint.org/docs/user-guide/configuring#configuration-file-formats)*
 
 #### Before
-
-*You'll want to extend from `eslint-config-uber-es5` first since some jsx rules depend on the base rules.*
 
 ```js
 {
   "rules": {},
-  "extends": [
-    "eslint-config-uber-es5"
-  ]
+  "extends": []
 }
 ```
 
@@ -41,13 +37,16 @@ Initialize a `.eslintrc` file or append to an existing one.
 {
   "rules": {},
   "extends": [
-    "eslint-config-uber-es5",
     "eslint-config-uber-jsx"
   ]
 }
 ```
 
-See [eslint docs](http://eslint.org/) for more information.
+*`eslint-config-uber-es5` is already included, so there's no need to extend it.*
+
+===
+
+[:back: to uber-eslint home](../../README.md)
 
 [npm-image]: https://badge.fury.io/js/eslint-config-uber-jsx.svg
 [npm-url]: https://npmjs.org/package/eslint-config-uber-jsx

--- a/packages/eslint-config-uber-jsx/package.json
+++ b/packages/eslint-config-uber-jsx/package.json
@@ -29,9 +29,8 @@
     "test": "node test/index.js"
   },
   "devDependencies": {
-    "eslint-config-uber-es5": "^1.0.0",
-    "eslint-config-uber-es2015": "^1.0.0",
     "eslint": "^2.3.0",
+    "eslint-config-uber-es2015": "^1.0.0",
     "eslint-plugin-react": "^5.0.0",
     "tape": "^4.0.0"
   },
@@ -42,5 +41,8 @@
     "node": ">=0.10.0",
     "npm": ">=2.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "eslint-config-uber-es5": "^1.0.0"
+  }
 }

--- a/packages/eslint-config-uber-jsx/test/fixtures/fail.jsx
+++ b/packages/eslint-config-uber-jsx/test/fixtures/fail.jsx
@@ -18,14 +18,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-'use strict';
+undef = 'test';
 var unusedVar = 'test';
-export default function Something({ something }) {
-  return (
-    <test className='test'>{ something.test }</test>
-  );
-}
+var Something = React.createClass({
+  render: function render(something) {
+    return <div className='test'>{something.test}</div>;
+  }
+});
 
-City.propTypes = {
-  city: PropTypes.object.isRequired
+Something.propTypes = {
+  something: React.PropTypes.object.isRequired
 };

--- a/packages/eslint-config-uber-jsx/test/fixtures/pass.jsx
+++ b/packages/eslint-config-uber-jsx/test/fixtures/pass.jsx
@@ -18,14 +18,15 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React, {PropTypes} from 'react';
+'use strict';
+var React = require('react');
 
-export default function Something({something}) {
-  return (
-    <div className="test">{something.test}</div>
-  );
-}
+var Something = React.createClass({
+  render: function render(something) {
+    return <div className="test">{something.test}</div>;
+  }
+});
 
 Something.propTypes = {
-  something: PropTypes.object.isRequired
+  something: React.PropTypes.object.isRequired
 };

--- a/packages/eslint-config-uber-jsx/test/index.js
+++ b/packages/eslint-config-uber-jsx/test/index.js
@@ -36,7 +36,7 @@ test('eslint file', function t(assert) {
 
 test('a passing lint', function t(assert) {
   var lintFile = path.join(__dirname, 'fixtures/pass.jsx');
-  exec('eslint -c .eslintrc.test.json ' + lintFile, function onLint(err, stderr, stdout) {
+  exec('eslint ' + lintFile, function onLint(err, stderr, stdout) {
     assert.ifError(err, 'does not error');
     assert.equal(stderr.toString(), '',
       'passes all linting');
@@ -46,7 +46,7 @@ test('a passing lint', function t(assert) {
 
 test('a failing lint', function t(assert) {
   var lintFile = path.join(__dirname, 'fixtures/fail.jsx');
-  exec('eslint -c .eslintrc.test.json ' + lintFile, function onLint(err, stderr, stdout) {
+  exec('eslint ' + lintFile, function onLint(err, stderr, stdout) {
     assert.ok(err, 'exits with non-zero exit code');
     stderr = stderr.toString();
     assert.ok(stderr.indexOf('strict') >= 0,
@@ -57,12 +57,22 @@ test('a failing lint', function t(assert) {
       'fails react/react-in-jsx-scope rule');
     assert.ok(stderr.indexOf('jsx-quotes') >= 0,
       'fails the jsx-quotes rule');
-    assert.ok(stderr.indexOf('no-var') >= 0,
-      'fails the no-var rule');
     assert.ok(stderr.indexOf('no-undef') >= 0,
       'fails the no-undef rule');
     assert.ok(stderr.indexOf('no-unused-vars') >= 0,
       'fails the no-unused-vars rule');
+    assert.end();
+  });
+});
+
+test('es2015 integration - a failing lint', function t(assert) {
+  var lintFile = path.join(__dirname, 'fixtures/fail.jsx');
+  exec('eslint -c .eslintrc.es2015.json ' + lintFile, function onLint(err, stderr, stdout) {
+    assert.ok(err, 'exits with non-zero exit code');
+    stderr = stderr.toString();
+    // ensures that extending uber-es2015 does not mangle uber-jsx override
+    assert.ok(stderr.indexOf('camelcase') === -1,
+      'passes the camelcase rule');
     assert.end();
   });
 });


### PR DESCRIPTION
Previously, users needed to manually include `eslint-config-uber-es5` as a dependency in order to have functional jsx rules. With this change, users are now able to ignore that and simply plug in `eslint-config-uber-es2015` or `eslint-config-uber-jsx` and go.

The intention is that eventually after es2017 is published, the dependency chain will be: 

`eslint-config-uber-es2017` -> `eslint-config-uber-es2015` -> `eslint-config-uber-es5`

And so-on as more ecmascript versions are published. 