### PR TITLE
jsx footguns and styling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# EditorConfig: http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
-  "lerna": "2.0.0-beta.23",
+  "lerna": "2.0.0-beta.30",
   "version": "independent"
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-      "url": "github:uber-web/uber-eslint"
+    "url": "github:uber-web/uber-eslint"
   },
   "scripts": {
     "bootstrap": "lerna bootstrap",
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "coveralls": "^2.11.12",
-    "lerna": "2.0.0-beta.23",
+    "lerna": "2.0.0-beta.30",
     "nyc": "^7.1.0"
   },
   "engines": {

--- a/packages/eslint-config-uber-es5/.eslintrc.json
+++ b/packages/eslint-config-uber-es5/.eslintrc.json
@@ -136,7 +136,7 @@
       "nofunc"
     ],
     "no-useless-call": 2,
-    "no-void": 0,
+    "no-void": 1,
     "no-var": 0,
     "prefer-const": 0,
     "no-warning-comments": [
@@ -334,13 +334,6 @@
     ],
     "strict": [2, "global"],
     "use-isnan": 2,
-    "valid-jsdoc": [
-      2,
-      {
-        "requireReturn": false,
-        "requireParamDescription": false
-      }
-    ],
     "valid-typeof": 2,
     "vars-on-top": 0,
     "wrap-iife": 2,

--- a/packages/eslint-config-uber-jsx/.eslintrc.json
+++ b/packages/eslint-config-uber-jsx/.eslintrc.json
@@ -36,7 +36,8 @@
       {
         "forbid": ["any", "array"]
       }
-    ]
+    ],
+    "react/prefer-stateless-function": 1
   },
   "plugins": [
     "react"

--- a/packages/eslint-config-uber-jsx/.eslintrc.json
+++ b/packages/eslint-config-uber-jsx/.eslintrc.json
@@ -30,7 +30,6 @@
     "react/no-direct-mutation-state": 1,
     "react/no-unknown-property": 1,
     "react/jsx-indent": [1, 2],
-    "react/jsx-no-literals": 1,
     "react/jsx-no-target-blank": 1,
     "react/forbid-prop-types": [
       1,

--- a/packages/eslint-config-uber-jsx/.eslintrc.json
+++ b/packages/eslint-config-uber-jsx/.eslintrc.json
@@ -11,9 +11,6 @@
     "experimentalObjectRestSpread": true
   },
   "rules": {
-    "block-scoped-var": 0,
-    "no-extra-parens": 0,
-    "camelcase": 0,
     "jsx-quotes": [2, "prefer-double"],
     "react/jsx-no-undef": 2,
     "react/no-unknown-property": 2,
@@ -26,7 +23,24 @@
     "react/react-in-jsx-scope": 2,
     "react/self-closing-comp": 2,
     "react/sort-comp": 1,
-    "react/wrap-multilines": 2
+    "react/jsx-wrap-multilines": 2,
+    "react/display-name": 1,
+    "react/no-danger": 1,
+    "react/no-danger-with-children": 1,
+    "react/no-deprecated": 1,
+    "react/no-direct-mutation-state": 1,
+    "react/no-unknown-property": 1,
+    "react/jsx-indent": 1,
+    "react/jsx-no-literals": 1,
+    "react/jsx-no-target-blank": 1,
+    "react/jsx-no-undef": 1,
+    "react/jsx-wrap-multilines": 1,
+    "react/forbid-prop-types": [
+      1,
+      {
+        "forbid": ["any", "array"]
+      }
+    ]
   },
   "plugins": [
     "react"

--- a/packages/eslint-config-uber-jsx/.eslintrc.json
+++ b/packages/eslint-config-uber-jsx/.eslintrc.json
@@ -23,7 +23,7 @@
     "react/react-in-jsx-scope": 2,
     "react/self-closing-comp": 2,
     "react/sort-comp": 1,
-    "react/jsx-wrap-multilines": 2,
+    "react/wrap-multilines": 2,
     "react/display-name": 1,
     "react/no-danger": 1,
     "react/no-deprecated": 1,

--- a/packages/eslint-config-uber-jsx/.eslintrc.json
+++ b/packages/eslint-config-uber-jsx/.eslintrc.json
@@ -26,15 +26,12 @@
     "react/jsx-wrap-multilines": 2,
     "react/display-name": 1,
     "react/no-danger": 1,
-    "react/no-danger-with-children": 1,
     "react/no-deprecated": 1,
     "react/no-direct-mutation-state": 1,
     "react/no-unknown-property": 1,
     "react/jsx-indent": 1,
     "react/jsx-no-literals": 1,
     "react/jsx-no-target-blank": 1,
-    "react/jsx-no-undef": 1,
-    "react/jsx-wrap-multilines": 1,
     "react/forbid-prop-types": [
       1,
       {

--- a/packages/eslint-config-uber-jsx/.eslintrc.json
+++ b/packages/eslint-config-uber-jsx/.eslintrc.json
@@ -29,7 +29,7 @@
     "react/no-deprecated": 1,
     "react/no-direct-mutation-state": 1,
     "react/no-unknown-property": 1,
-    "react/jsx-indent": 1,
+    "react/jsx-indent": [1, 2],
     "react/jsx-no-literals": 1,
     "react/jsx-no-target-blank": 1,
     "react/forbid-prop-types": [

--- a/packages/eslint-config-uber-jsx/test/fixtures/pass.jsx
+++ b/packages/eslint-config-uber-jsx/test/fixtures/pass.jsx
@@ -21,11 +21,9 @@
 'use strict';
 var React = require('react');
 
-var Something = React.createClass({
-  render: function render(something) {
-    return <div className="test">{something.test}</div>;
-  }
-});
+function Something(something) {
+  return <div className="test">{something.test}</div>;
+}
 
 Something.propTypes = {
   something: React.PropTypes.object.isRequired


### PR DESCRIPTION
Patch bump with the following ⚠️ 's added. After merging, these will be changed to errors and major will be bumped:

The following were all enabled:

* [react/display-name](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/display-name.md): DisplayName allows you to name your component. This name is used by React in debugging messages.

* [react/no-danger](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-danger.md): Dangerous properties in React are those whose behavior is known to be a common source of application vulnerabilities. The properties names clearly indicate they are dangerous and should be avoided unless great care is taken.


* [react/no-deprecated](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-deprecated.md): Several methods are deprecated between React versions. This rule will warn you if you try to use a deprecated method.

* [react/no-direct-mutation-state](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-direct-mutation-state.md): NEVER mutate this.state directly, as calling setState() afterwards may replace the mutation you made. Treat this.state as if it were immutable.

* [react/no-unknown-property](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md): In JSX all DOM properties and attributes should be camelCased to be consistent with standard JavaScript style. This can be a possible source of error if you are used to writing plain HTML.

* [react/jsx-indent](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent.md): This option validates a specific indentation style for JSX.

* [react/jsx-no-target-blank](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md): When creating a JSX element that has an a tag, it is often desired to have the link open in a new tab using the target='_blank' attribute. Using this attribute unaccompanied by rel='noreferrer noopener', however, is a severe security vulnerability (see here for more details) This rules requires that you accompany all target='_blank' attributes with rel='noreferrer noopener'.

* [react/jsx-no-undef](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-undef.md): 
This rule helps locate potential ReferenceErrors resulting from misspellings or missing components.

* [react/forbid-prop-types](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md): By default this rule prevents vague prop types with more specific alternatives available (any, array, object), but any prop type can be disabled if desired. The defaults are chosen because they have obvious replacements. any should be replaced with, well, anything. array and object can be replaced with arrayOf and shape, respectively.

* [react/prefer-stateless-function](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-stateless-function.md): Stateless functional components are simpler than class based components and will benefit from future React performance optimizations specific to these components.

## es5

* [no-void](http://eslint.org/docs/rules/no-void): The void operator takes an operand and returns undefined: void expression will evaluate expression and return undefined. It can be used to ignore any side effects expression may produce: