### PR TITLE
:sparkles: add arrow-spacing rule

### DIFF
--- a/packages/eslint-config-uber-es2015/ecmascript-6.json
+++ b/packages/eslint-config-uber-es2015/ecmascript-6.json
@@ -1,5 +1,6 @@
 {
   "rules": {
+    "no-class-assign": 2,
     "arrow-spacing": [
       1,
       {

--- a/packages/eslint-config-uber-es2015/ecmascript-6.json
+++ b/packages/eslint-config-uber-es2015/ecmascript-6.json
@@ -1,6 +1,12 @@
 {
   "rules": {
-    "no-class-assign": 2,
+    "arrow-spacing": [
+      1,
+      {
+        "before": true,
+        "after": true
+      }
+    ],
     "no-const-assign": 2,
     "no-dupe-class-members": 2,
     "no-this-before-super": 2,

--- a/packages/eslint-config-uber-es2015/test/index.js
+++ b/packages/eslint-config-uber-es2015/test/index.js
@@ -59,6 +59,8 @@ test('a failing lint', function t(assert) {
       'fails arrow-spacing rule');
     assert.ok(stderr.indexOf('no-var') >= 0,
       'fails the no-var rule');
+    assert.ok(stderr.indexOf('arrow-spacing') >= 0,
+      'fails the arrow-spacing rule');
 
     // miscellaneous
 


### PR DESCRIPTION
Good

```js
(a) => {}
```

Bad (set to warning)

```js
()=> {};
() =>{};
(a)=> {};
(a) =>{};
a =>a;
a=> a;
()=> {'\n'};
() =>{'\n'};
```

Will be a minor version bump