### PR TITLE
Update eslint-plugin-react version to 7.4.0

### DIFF
--- a/packages/eslint-config-uber-jsx/package.json
+++ b/packages/eslint-config-uber-jsx/package.json
@@ -39,6 +39,6 @@
   "license": "MIT",
   "dependencies": {
     "eslint-config-uber-es5": "^2.0.3",
-    "eslint-plugin-react": "^6.7.1"
+    "eslint-plugin-react": "^7.4.0"
   }
 }

--- a/packages/eslint-config-uber-jsx/package.json
+++ b/packages/eslint-config-uber-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-uber-jsx",
-  "version": "3.3.3",
+  "version": "4.0.0",
   "description": "The base jsx eslint config for web JavaScript at Uber",
   "keywords": [
     "eslint",

--- a/packages/eslint-config-uber-jsx/test/fixtures/pass.jsx
+++ b/packages/eslint-config-uber-jsx/test/fixtures/pass.jsx
@@ -19,8 +19,8 @@
 // THE SOFTWARE.
 
 'use strict';
-var React = require('react');
 var propTypes = require('prop-types');
+var React = require('react');
 
 function Something(something) {
   return <div className="test">{something.test}</div>;

--- a/packages/eslint-config-uber-jsx/test/fixtures/pass.jsx
+++ b/packages/eslint-config-uber-jsx/test/fixtures/pass.jsx
@@ -20,12 +20,12 @@
 
 'use strict';
 var React = require('react');
-var PropTypes = require('prop-types');
+var propTypes = require('prop-types');
 
 function Something(something) {
   return <div className="test">{something.test}</div>;
 }
 
 Something.propTypes = {
-  something: PropTypes.object.isRequired
+  something: propTypes.object.isRequired
 };

--- a/packages/eslint-config-uber-jsx/test/fixtures/pass.jsx
+++ b/packages/eslint-config-uber-jsx/test/fixtures/pass.jsx
@@ -20,11 +20,12 @@
 
 'use strict';
 var React = require('react');
+var PropTypes = require('prop-types');
 
 function Something(something) {
   return <div className="test">{something.test}</div>;
 }
 
 Something.propTypes = {
-  something: React.PropTypes.object.isRequired
+  something: PropTypes.object.isRequired
 };


### PR DESCRIPTION
This update allows `npm shrinkwrap` to run cleanly when using eslint v4. Version 7.4.0 of eslint-plugin-react supports eslint v4 as a peer dependency.