### PR TITLE
Proposal: Enforce a longer maximum line length of 100 characters

### DIFF
--- a/packages/eslint-config-uber-base/index.js
+++ b/packages/eslint-config-uber-base/index.js
@@ -35,7 +35,7 @@ module.exports = {
     'prettier/prettier': [
       'error',
       {
-        printWidth: 80,
+        printWidth: 100,
         tabWidth: 2,
         useTabs: false,
         semi: true,


### PR DESCRIPTION
Changing the maximum line-length to 100 characters lowers screen wastage while still ensuring that horizontal scrolling should not be necessary in most cases.

Historically, the 80 character limit comes from [IBM Punchcards](https://softwareengineering.stackexchange.com/questions/148677/why-is-80-characters-the-standard-limit-for-code-width) and later smaller, lower-resolution terminals.

Today, we have 1920x1080 or higher resolution monitors which can fit more code realestate that need not be constricted to the same standard.

*Pros:*
- More code can fit on the screen
- Fewer lines of code
- Fewer cases of enforcing arbitrarily splitting line logic across multiple lines when not necessary

*Cons:*
- Deviates from prettier default
- Cannot fit four code tabs horizontally across anymore
- Complex logic may be forced into a single line

As an added test, [GitHub's diff below allows for >100 characters split side-by-side](https://stackoverflow.com/questions/22207920/what-is-githubs-character-limit-or-line-length-for-viewing-files-on-github) with no scrolling necessary:

> On OSX 10.9:
> Google Chrome: 125
> Firefox: 122
> Safari: 121