### PR TITLE
Upgrade to eslint@5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.9.0
+FROM node:8.11.2
 
 WORKDIR /uber-eslint
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint ."
   },
   "devDependencies": {
-    "eslint": "^4.0.0",
+    "eslint": "^5.0.0",
     "eslint-config-prettier": "^2.0.0",
     "eslint-plugin-prettier": "^2.0.0",
     "lerna": "^2.0.0",

--- a/packages/eslint-config-uber-base-stage-3/package.json
+++ b/packages/eslint-config-uber-base-stage-3/package.json
@@ -19,7 +19,7 @@
   },
   "peerDependencies": {
     "babel-eslint": "^8.0.0",
-    "eslint": "^4.0.0"
+    "eslint": "^5.0.0"
   },
   "engines": {
     "node": ">= 6"

--- a/packages/eslint-config-uber-base/package.json
+++ b/packages/eslint-config-uber-base/package.json
@@ -18,7 +18,7 @@
     "eslint-config-prettier": "^2.0.0"
   },
   "peerDependencies": {
-    "eslint": "^4.0.0",
+    "eslint": "^5.0.0",
     "eslint-plugin-prettier": "^2.0.0"
   },
   "engines": {

--- a/packages/eslint-config-uber-browser-stage-3/package.json
+++ b/packages/eslint-config-uber-browser-stage-3/package.json
@@ -18,7 +18,7 @@
     "eslint-config-uber-base-stage-3": "^1.0.0-rc.7"
   },
   "peerDependencies": {
-    "eslint": "^4.0.0"
+    "eslint": "^5.0.0"
   },
   "engines": {
     "node": ">= 6"

--- a/packages/eslint-config-uber-node-lts/package.json
+++ b/packages/eslint-config-uber-node-lts/package.json
@@ -18,7 +18,7 @@
     "eslint-config-uber-base": "^1.0.0-rc.7"
   },
   "peerDependencies": {
-    "eslint": "^4.0.0"
+    "eslint": "^5.0.0"
   },
   "engines": {
     "node": ">= 6"

--- a/packages/eslint-config-uber-node-stage-3/package.json
+++ b/packages/eslint-config-uber-node-stage-3/package.json
@@ -18,7 +18,7 @@
     "eslint-config-uber-base-stage-3": "^1.0.0-rc.7"
   },
   "peerDependencies": {
-    "eslint": "^4.0.0"
+    "eslint": "^5.0.0"
   },
   "engines": {
     "node": ">= 6"

--- a/packages/eslint-config-uber-universal-stage-3/package.json
+++ b/packages/eslint-config-uber-universal-stage-3/package.json
@@ -19,7 +19,7 @@
     "eslint-config-uber-base-stage-3": "^1.0.0-rc.7"
   },
   "peerDependencies": {
-    "eslint": "^4.0.0"
+    "eslint": "^5.0.0"
   },
   "engines": {
     "node": ">= 6"


### PR DESCRIPTION
This is necessary in order to fix Fusion.js peerDependency warnings. This will also mean bumping most packages to a 2.0, or since we're on a 1.0 RC, maybe we could just go to 1.0.