### PR TITLE
Update no-unused-vars config

### DIFF
--- a/packages/eslint-config-uber-base/index.js
+++ b/packages/eslint-config-uber-base/index.js
@@ -31,6 +31,10 @@ module.exports = {
   ],
 
   rules: {
+    'no-unused-vars': [
+      'error',
+      {vars: 'all', args: 'none', ignoreRestSiblings: true},
+    ],
     // Prettier settings
     'prettier/prettier': [
       'error',


### PR DESCRIPTION
Having unused variables as function arguments can be useful for having self documenting code. ignoreRestSiblings is useful for omitting properties from objects without any dependencies.