### PR TITLE
Update deps and peerDeps to avoid warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "eslint": "^5.0.0",
     "eslint-config-prettier": "^2.0.0",
-    "eslint-plugin-prettier": "^2.0.0",
+    "eslint-plugin-prettier": "^3.0.0",
     "lerna": "^2.0.0",
     "prettier": "1.7.0"
   },

--- a/packages/eslint-config-uber-base-stage-3/package.json
+++ b/packages/eslint-config-uber-base-stage-3/package.json
@@ -18,7 +18,7 @@
     "eslint-config-uber-base": "^2.1.0"
   },
   "peerDependencies": {
-    "babel-eslint": "^8.0.0",
+    "babel-eslint": "^10.0.0",
     "eslint": "^5.0.0"
   },
   "engines": {

--- a/packages/eslint-config-uber-base/package.json
+++ b/packages/eslint-config-uber-base/package.json
@@ -15,11 +15,11 @@
   },
   "main": "index.js",
   "dependencies": {
-    "eslint-config-prettier": "^2.0.0"
+    "eslint-config-prettier": "^3.1.0"
   },
   "peerDependencies": {
     "eslint": "^5.0.0",
-    "eslint-plugin-prettier": "^2.0.0"
+    "eslint-plugin-prettier": "^3.0.0"
   },
   "engines": {
     "node": ">= 6"

--- a/packages/eslint-config-uber-universal-stage-3/package.json
+++ b/packages/eslint-config-uber-universal-stage-3/package.json
@@ -15,7 +15,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "eslint-config-cup": "^2.0.0",
+    "eslint-config-cup": "^2.0.1",
     "eslint-config-uber-base-stage-3": "^2.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Installing this package currently results in peerDependency warnings due to outdated peerDep requirements. Update these dependencies to get around the warnings.

We should release a new breaking version of this due to the following updates:

eslint-config-prettier@3.x
* Breaking change: Dropped Node.js 4 support.

babel-eslint
* Now requiring a new major version as a peerDep.
