### PR TITLE
Remove prettier parser option

### DIFF
--- a/packages/eslint-config-uber-base/index.js
+++ b/packages/eslint-config-uber-base/index.js
@@ -49,7 +49,6 @@ module.exports = {
         jsxBracketSameLine: false,
         rangeStart: 0,
         rangeEnd: Infinity,
-        parser: 'babylon',
       },
     ],
     // We should have a very high bar for adding additional rules here.


### PR DESCRIPTION
This fixes deprecation warnings due to the `babylon` parser [being renamed](https://prettier.io/blog/2019/01/20/1.16.0.html#rename-babylon-parser-to-babel-5647-by-wuweiweiwu) to `babel` in v1.16.0. Also, prettier [recommends](https://prettier.io/docs/en/configuration.html#setting-the-parser-docs-en-optionshtml-parser-option) not providing this option at the top-level; it will infer the `babel` parser for js files by default:

> Note: *Never* put the `parser` option at the top level of your configuration. *Only* use it inside `overrides`. Otherwise you effectively disable Prettier's automatic file extension based parser inference. This forces Prettier to use the parser you specified for *all* types of files – even when it doesn't make sense, such as trying to parse a CSS file as JavaScript.