### PR TITLE
bump deps for uber-eslint and replace deprecated jsxBracketSameLine

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: require.resolve('./packages/eslint-config-uber-base/index.js'),
   env: {
-    node: true
-  }
+    node: true,
+  },
 };

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.11.2
+FROM node:16.15.0
 
 WORKDIR /uber-eslint
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.0.0",
+  "lerna": "5.1.0",
   "packages": [
     "packages/*"
   ],

--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
     "lint": "eslint ."
   },
   "devDependencies": {
-    "eslint": "^5.0.0",
+    "eslint": "^7.18.0",
     "eslint-config-prettier": "^2.0.0",
     "eslint-plugin-prettier": "^3.0.0",
-    "lerna": "^2.0.0",
+    "lerna": "^5.1.0",
     "prettier": "^1.7.0"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=16.15.0"
   },
   "license": "MIT"
 }

--- a/packages/eslint-config-uber-base-stage-3/package.json
+++ b/packages/eslint-config-uber-base-stage-3/package.json
@@ -19,10 +19,10 @@
   },
   "peerDependencies": {
     "babel-eslint": "^10.0.0",
-    "eslint": "^5.0.0 || ^6.0.0"
+    "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 16"
   },
   "license": "MIT"
 }

--- a/packages/eslint-config-uber-base/index.js
+++ b/packages/eslint-config-uber-base/index.js
@@ -46,7 +46,7 @@ module.exports = {
         singleQuote: true,
         trailingComma: 'es5',
         bracketSpacing: false,
-        jsxBracketSameLine: false,
+        bracketSameLine: false,
         rangeStart: 0,
         rangeEnd: Infinity,
       },

--- a/packages/eslint-config-uber-base/package.json
+++ b/packages/eslint-config-uber-base/package.json
@@ -18,11 +18,11 @@
     "eslint-config-prettier": "^3.1.0"
   },
   "peerDependencies": {
-    "eslint": "^5.0.0 || ^6.0.0",
+    "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0",
     "eslint-plugin-prettier": "^3.0.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 16"
   },
   "license": "MIT"
 }

--- a/packages/eslint-config-uber-browser-stage-3/package.json
+++ b/packages/eslint-config-uber-browser-stage-3/package.json
@@ -18,10 +18,10 @@
     "eslint-config-uber-base-stage-3": "^3.0.2"
   },
   "peerDependencies": {
-    "eslint": "^5.0.0 || ^6.0.0"
+    "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 16"
   },
   "license": "MIT"
 }

--- a/packages/eslint-config-uber-node-lts/package.json
+++ b/packages/eslint-config-uber-node-lts/package.json
@@ -18,10 +18,10 @@
     "eslint-config-uber-base": "^3.0.2"
   },
   "peerDependencies": {
-    "eslint": "^5.0.0 || ^6.0.0"
+    "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 16"
   },
   "license": "MIT"
 }

--- a/packages/eslint-config-uber-node-stage-3/package.json
+++ b/packages/eslint-config-uber-node-stage-3/package.json
@@ -18,10 +18,10 @@
     "eslint-config-uber-base-stage-3": "^3.0.2"
   },
   "peerDependencies": {
-    "eslint": "^5.0.0 || ^6.0.0"
+    "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 16"
   },
   "license": "MIT"
 }

--- a/packages/eslint-config-uber-universal-stage-3/package.json
+++ b/packages/eslint-config-uber-universal-stage-3/package.json
@@ -19,10 +19,10 @@
     "eslint-config-uber-base-stage-3": "^3.0.2"
   },
   "peerDependencies": {
-    "eslint": "^5.0.0 || ^6.0.0"
+    "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 16"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
See this -- https://prettier.io/docs/en/options.html#deprecated-jsx-brackets

https://prettier.io/blog/2021/09/09/2.4.0.html

> This release renames the jsxBracketSameLine option to bracketSameLine, which supports HTML, Vue, and Angular in addition to JSX. The old name has been deprecated.

Change jsxBracketSameLine -> bracketSameLine

Also took the opportunity to update the deps / devDeps so it matches Uber's monorepo versions.