### PR TITLE
bump to v4.0.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.0.2"
+  "version": "4.0.0"
 }

--- a/packages/eslint-config-uber-base-stage-3/package.json
+++ b/packages/eslint-config-uber-base-stage-3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-uber-base-stage-3",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "description": "Base ESlint config for Stage 3+ JS",
   "author": "Web Platform Team <eng-web-platform@uber.com>",
   "bugs": {
@@ -15,7 +15,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "eslint-config-uber-base": "^3.0.2"
+    "eslint-config-uber-base": "^4.0.0"
   },
   "peerDependencies": {
     "babel-eslint": "^10.0.0",

--- a/packages/eslint-config-uber-base/package.json
+++ b/packages/eslint-config-uber-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-uber-base",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "description": "Base ESlint config",
   "author": "Web Platform Team <eng-web-platform@uber.com>",
   "bugs": {

--- a/packages/eslint-config-uber-browser-stage-3/package.json
+++ b/packages/eslint-config-uber-browser-stage-3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-uber-browser-stage-3",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "description": "ESlint config for browser with Stage 3+ JS",
   "author": "Web Platform Team <eng-web-platform@uber.com>",
   "bugs": {
@@ -15,7 +15,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "eslint-config-uber-base-stage-3": "^3.0.2"
+    "eslint-config-uber-base-stage-3": "^4.0.0"
   },
   "peerDependencies": {
     "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"

--- a/packages/eslint-config-uber-node-lts/package.json
+++ b/packages/eslint-config-uber-node-lts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-uber-node-lts",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "description": "ESlint config for Node LTS",
   "author": "Web Platform Team <eng-web-platform@uber.com>",
   "bugs": {
@@ -15,7 +15,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "eslint-config-uber-base": "^3.0.2"
+    "eslint-config-uber-base": "^4.0.0"
   },
   "peerDependencies": {
     "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"

--- a/packages/eslint-config-uber-node-stage-3/package.json
+++ b/packages/eslint-config-uber-node-stage-3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-uber-node-stage-3",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "description": "ESlint config for Node with Stage 3+ JS",
   "author": "Web Platform Team <eng-web-platform@uber.com>",
   "bugs": {
@@ -15,7 +15,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "eslint-config-uber-base-stage-3": "^3.0.2"
+    "eslint-config-uber-base-stage-3": "^4.0.0"
   },
   "peerDependencies": {
     "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"

--- a/packages/eslint-config-uber-universal-stage-3/package.json
+++ b/packages/eslint-config-uber-universal-stage-3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-uber-universal-stage-3",
-  "version": "3.0.2",
+  "version": "4.0.0",
   "description": "ESlint config for Stage 3+ universal JS",
   "author": "Web Platform Team <eng-web-platform@uber.com>",
   "bugs": {
@@ -16,7 +16,7 @@
   "main": "index.js",
   "dependencies": {
     "eslint-config-cup": "^2.0.1",
-    "eslint-config-uber-base-stage-3": "^3.0.2"
+    "eslint-config-uber-base-stage-3": "^4.0.0"
   },
   "peerDependencies": {
     "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"


### PR DESCRIPTION
We bumped node to v16 and removed deprecated rules as described in #39 